### PR TITLE
Add Dockerfile to start both backend and frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Multi-stage Dockerfile for building and running both backend and frontend
+
+# Stage 1: Build backend
+FROM node:20 AS backend-builder
+WORKDIR /app/backend
+COPY backend/package.json backend/pnpm-lock.yaml ./
+RUN npm install -g pnpm && pnpm install
+COPY backend .
+RUN pnpm build
+
+# Stage 2: Build frontend
+FROM node:20 AS frontend-builder
+WORKDIR /app/frontend
+COPY frontend/admin/package.json frontend/admin/pnpm-lock.yaml ./
+RUN npm install -g pnpm && pnpm install
+COPY frontend/admin .
+RUN pnpm build
+
+# Stage 3: Run backend and frontend
+FROM node:20
+WORKDIR /app
+
+# Copy backend build
+COPY --from=backend-builder /app/backend/dist ./backend/dist
+COPY --from=backend-builder /app/backend/node_modules ./backend/node_modules
+COPY --from=backend-builder /app/backend/package.json ./backend/package.json
+
+# Copy frontend build
+COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
+COPY --from=frontend-builder /app/frontend/node_modules ./frontend/node_modules
+COPY --from=frontend-builder /app/frontend/package.json ./frontend/package.json
+
+# Install serve to serve the frontend
+RUN npm install -g serve
+
+# Set environment variables
+ENV NODE_ENV=production
+ENV PORT=3000
+
+# Expose ports
+EXPOSE 3000
+EXPOSE 5173
+
+# Start both backend and frontend
+CMD ["sh", "-c", "node backend/dist/main.js & serve -s frontend/dist -l 5173"]

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ The system follows a modular architecture separating frontend, backend, and data
 
 ## Prerequisites
 
-- Node.js (v18 or higher)
+- Node.js (v20 or higher)
 - pnpm
 - PostgreSQL
 - Redis
+- Docker
 
 ## Getting Started
 
@@ -138,6 +139,19 @@ pnpm dev
 ```
 
 The admin dashboard will be available at `http://localhost:5173`
+
+### Using Docker
+
+1. Build and run the Docker containers:
+
+```bash
+docker-compose up --build
+```
+
+2. Access the services:
+
+- Backend API: `http://localhost:3000`
+- Admin Dashboard: `http://localhost:5173`
 
 ## Development Guidelines
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: backend-builder
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - DATABASE_URL=${DATABASE_URL}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRATION=${JWT_EXPIRATION}
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
+      - CACHE_TTL=${CACHE_TTL}
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+      - redis
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: frontend-builder
+    environment:
+      - NODE_ENV=production
+      - VITE_API_URL=${VITE_API_URL}
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+
+  db:
+    image: postgres:13
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:6
+    ports:
+      - "6379:6379"
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
Fixes #8

Add Dockerfile and docker-compose.yml to start both backend and frontend services.

* **Dockerfile**: Create a multi-stage Dockerfile to build and run both backend and frontend using Node.js 20. Copy backend and frontend files, install dependencies, build, and set up commands to start both services.
* **docker-compose.yml**: Define services for backend and frontend, use Dockerfile to build both services, set up environment variables, and expose necessary ports. Include dependencies on db and redis services.
* **README.md**: Update prerequisites to include Docker and Node.js 20. Add instructions for using Docker to start both backend and frontend, including commands to build and run Docker containers.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/frisorsalong-booking/pull/9?shareId=8836b568-afc8-4b23-bc43-5d4bdb4f8a9f).