### PR TITLE
Simplify mock entity classes in tests

### DIFF
--- a/backend/src/app.module.spec.ts
+++ b/backend/src/app.module.spec.ts
@@ -119,27 +119,39 @@ jest.mock("./shops/shops.module", () => ({
 
 // Mock entities
 jest.mock("./users/entities/user.entity", () => ({
-  User: class MockUser {},
+  User: class MockUser {
+    id = "";
+  },
 }));
 
 jest.mock("./employees/entities/employee.entity", () => ({
-  Employee: class MockEmployee {},
+  Employee: class MockEmployee {
+    id = "";
+  },
 }));
 
 jest.mock("./services/entities/service.entity", () => ({
-  Service: class MockService {},
+  Service: class MockService {
+    id = "";
+  },
 }));
 
 jest.mock("./bookings/entities/booking.entity", () => ({
-  Booking: class MockBooking {},
+  Booking: class MockBooking {
+    id = "";
+  },
 }));
 
 jest.mock("./orders/entities/order.entity", () => ({
-  Order: class MockOrder {},
+  Order: class MockOrder {
+    id = "";
+  },
 }));
 
 jest.mock("./shops/entities/shop-code.entity", () => ({
-  ShopCode: class MockShopCode {},
+  ShopCode: class MockShopCode {
+    id = "";
+  },
 }));
 
 interface TypeOrmModuleOptions {

--- a/backend/src/app.module.spec.ts
+++ b/backend/src/app.module.spec.ts
@@ -119,39 +119,27 @@ jest.mock("./shops/shops.module", () => ({
 
 // Mock entities
 jest.mock("./users/entities/user.entity", () => ({
-  User: class MockUser {
-    constructor() {}
-  },
+  User: class MockUser {},
 }));
 
 jest.mock("./employees/entities/employee.entity", () => ({
-  Employee: class MockEmployee {
-    constructor() {}
-  },
+  Employee: class MockEmployee {},
 }));
 
 jest.mock("./services/entities/service.entity", () => ({
-  Service: class MockService {
-    constructor() {}
-  },
+  Service: class MockService {},
 }));
 
 jest.mock("./bookings/entities/booking.entity", () => ({
-  Booking: class MockBooking {
-    constructor() {}
-  },
+  Booking: class MockBooking {},
 }));
 
 jest.mock("./orders/entities/order.entity", () => ({
-  Order: class MockOrder {
-    constructor() {}
-  },
+  Order: class MockOrder {},
 }));
 
 jest.mock("./shops/entities/shop-code.entity", () => ({
-  ShopCode: class MockShopCode {
-    constructor() {}
-  },
+  ShopCode: class MockShopCode {},
 }));
 
 interface TypeOrmModuleOptions {


### PR DESCRIPTION
- Remove redundant empty constructor definitions from mocked entity classes in backend/src/app.module.spec.ts (User, Employee, Service, Booking, Order, ShopCode). Cleans up jest mocks and reduces boilerplate with no functional change to tests.